### PR TITLE
Ensure narrow icons don't break tree alignment

### DIFF
--- a/source/font-awesome.css
+++ b/source/font-awesome.css
@@ -1,3 +1,8 @@
+.umb-tree-icon {
+    width: 20px;
+    text-align: center;
+}
+
 /*!
  * Font Awesome Free 5.13.0 by @fontawesome - https://fontawesome.com
  * License - https://fontawesome.com/license/free (Icons: CC BY 4.0, Fonts: SIL OFL 1.1, Code: MIT License)


### PR DESCRIPTION
Hey Chris, 

I hope all is well for you. I've just been using your package (great work mate) and spotted an alignment issue in the Umbraco tree on certain icons. Here's a small suggested fix.

Cheers,
Matt

The native Umbraco icon font has every icon on a square canvas and so the width of the icon doesn't need to be set by CSS for everything to align, Most of the Font Awesome icons seem to be on a square canvas too, but a few icons are narrower in width. Although arguably perhaps this should perhaps be set by the Umbraco CSS, this CSS tweak restores the alignment.